### PR TITLE
added in-memory table row highlight feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 
 node_modules
 

--- a/src/lib/components/ActionTable.svelte
+++ b/src/lib/components/ActionTable.svelte
@@ -19,7 +19,10 @@
 	let hasInput: boolean = $derived(actions.some((a) => a.input.length > 0));
 	let hasOutput: boolean = $derived(actions.some((a) => a.output.length > 0));
 
-	const state = getContext<LocalStore<State>>('state')?.value;
+	const playerState = getContext<LocalStore<State>>('state')?.value;
+
+	const rowIndexHighlights = $state({} as Record<number, boolean>);
+	const toggleIndex = (i: number) => (rowIndexHighlights[i] = !rowIndexHighlights[i]);
 </script>
 
 <div class="table-wrap">
@@ -43,8 +46,8 @@
 			</tr>
 		</thead>
 		<tbody class="hover:[&>tr]:preset-tonal-primary">
-			{#each actions as action}
-				<tr>
+			{#each actions as action, index}
+				<tr class={rowIndexHighlights[index] ? '[&&&]:preset-tonal-secondary' : ''} onclick={() => toggleIndex(index)}>
 					<td>
 						<LevelRequirementsDisplay reqs={action.requirements} />
 					</td>
@@ -68,7 +71,7 @@
 						<ExpsDisplay exps={action.experience} />
 					</td>
 					<td>
-						<ExpsDisplay exps={calculateExperiences(state, action)} />
+						<ExpsDisplay exps={calculateExperiences(playerState, action)} />
 					</td>
 					{#if hasInput && hasOutput}
 						<td>

--- a/src/routes/professions/[profession]/+page.svelte
+++ b/src/routes/professions/[profession]/+page.svelte
@@ -14,9 +14,11 @@
 <div class="flex flex-col items-center space-y-8">
 	<ProfessionInputField id={profession.id} />
 
-	<ActionTable actions={profession.actions} />
-	{#if profession.passives}
-		<PassiveActionTable actions={profession.passives} />
-	{/if}
-	<ActionsPerLevelChart id={data.profession.id} />
+	{#key profession}
+		<ActionTable actions={profession.actions} />
+		{#if profession.passives}
+			<PassiveActionTable actions={profession.passives} />
+		{/if}
+		<ActionsPerLevelChart id={data.profession.id} />
+	{/key}
 </div>


### PR DESCRIPTION
I felt that it would be helpful to be able to semi-permanently highlight a row in the ActionTable. It would make second-monitor tracking of actions a lot easier. Right now this feature exists only in memory, so it won't persist at all. But I think that's a good starting point.

I've never used tailwind before so it's possible I committed a sin by using the `[&&&]:` prefix to increase the specificity of the preset-tonal-secondary class. Please let me know if there's some way you think this could be improved!

I also threw .vscode into the gitignore since I save my code-workspace file there. Figured that wouldn't be controversial.